### PR TITLE
Enable trait derivation for tuple structs with a single, simply-typed field

### DIFF
--- a/tls_codec_derive/src/lib.rs
+++ b/tls_codec_derive/src/lib.rs
@@ -448,19 +448,16 @@ fn impl_serialize(parsed_ast: TlsStruct) -> TokenStream2 {
                 // This can probably be optimised such that we only have one
                 // `match` statement.
                 EnumStyle::TupleStruct => {
-                    let type_mapping: Vec<TokenStream2> = match enum_style {
-                        EnumStyle::Repr(_) => vec![],
-                        EnumStyle::TupleStruct => variants
-                            .iter()
-                            .map(|variant| {
-                                let variant = &variant.ident;
-                                let enum_type = &format_ident!("{}{}", ident, ENUM_TYPE_POSTFIX);
-                                quote! {
-                                    #ident::#variant(_) => #enum_type::#variant
-                                }
-                            })
-                            .collect(),
-                    };
+                    let type_mapping: Vec<TokenStream2> = variants
+                        .iter()
+                        .map(|variant| {
+                            let variant = &variant.ident;
+                            let enum_type = &format_ident!("{}{}", ident, ENUM_TYPE_POSTFIX);
+                            quote! {
+                                #ident::#variant(_) => #enum_type::#variant
+                            }
+                        })
+                        .collect();
 
                     let deconstructed_variants: Vec<TokenStream2> = variants
                         .iter()
@@ -584,27 +581,24 @@ fn impl_deserialize(parsed_ast: TlsStruct) -> TokenStream2 {
                     }
                 }
                 EnumStyle::TupleStruct => {
-                    let variant_mapping: Vec<TokenStream2> = match enum_style {
-                        EnumStyle::Repr(_) => vec![],
-                        EnumStyle::TupleStruct => variants
-                            .iter()
-                            .map(|variant| {
-                                let field_type = match variant.fields {
-                                    Fields::Unnamed(ref fields_unnamed) => fields_unnamed.unnamed.first().unwrap().ty.clone(),
-                                    _ => panic!("non-repr enums can only consist of tuple structs with a single unnamed field"),
-                                };
-                                let type_path = match field_type {
-                                    syn::Type::Path(tp) => tp.path,
-                                    _ => panic!("fields of the tuple struct can only have a simple path-style type"),
-                                };
-                                let variant_ident = &variant.ident;
-                                let enum_type = &format_ident!("{}{}", ident, ENUM_TYPE_POSTFIX);
-                                quote! {
-                                    #enum_type::#variant_ident => Ok(#ident::#variant_ident(#type_path::tls_deserialize(bytes)?))
-                                }
-                            })
-                            .collect(),
-                    };
+                    let variant_mapping: Vec<TokenStream2> = variants
+                        .iter()
+                        .map(|variant| {
+                            let field_type = match variant.fields {
+                                Fields::Unnamed(ref fields_unnamed) => fields_unnamed.unnamed.first().unwrap().ty.clone(),
+                                _ => panic!("non-repr enums can only consist of tuple structs with a single unnamed field"),
+                            };
+                            let type_path = match field_type {
+                                syn::Type::Path(tp) => tp.path,
+                                _ => panic!("fields of the tuple struct can only have a simple path-style type"),
+                            };
+                            let variant_ident = &variant.ident;
+                            let enum_type = &format_ident!("{}{}", ident, ENUM_TYPE_POSTFIX);
+                            quote! {
+                                #enum_type::#variant_ident => Ok(#ident::#variant_ident(#type_path::tls_deserialize(bytes)?))
+                            }
+                        })
+                        .collect();
                     let enum_type = &format_ident!("{}{}", ident, ENUM_TYPE_POSTFIX);
                     quote! {
                         impl tls_codec::Deserialize for #ident {

--- a/tls_codec_derive/tests/decode.rs
+++ b/tls_codec_derive/tests/decode.rs
@@ -66,8 +66,21 @@ fn tuple_struct() {
     );
 }
 
+#[derive(TlsDeserialize, TlsSize, Clone, PartialEq, Debug)]
+#[repr(u8)]
+enum SimpleEnumType {
+    One = 1u8,
+    Two = 2u8,
+}
+
+#[derive(TlsDeserialize, TlsSize, Clone, PartialEq)]
+enum SimpleEnum {
+    One(Credential),
+    Two(BasicCredential),
+}
+
 #[test]
-fn simple_enum() {
+fn simple_enums() {
     let mut b = &[0u8, 5] as &[u8];
     let deserialized = ExtensionType::tls_deserialize(&mut b).unwrap();
     assert_eq!(ExtensionType::RatchetTree, deserialized);
@@ -82,6 +95,19 @@ fn simple_enum() {
         let deserialized = ExtensionType::tls_deserialize(&mut b).unwrap();
         assert_eq!(variant, &deserialized);
     }
+
+    let mut one_serialized = &[1u8, 0, 0, 0, 0, 0, 0, 0, 0] as &[u8];
+    let mut two_serialized = &[2u8, 0, 0, 0, 0, 0, 0] as &[u8];
+
+    let one = SimpleEnum::tls_deserialize(&mut one_serialized).expect("Error deserializing.");
+    let two = SimpleEnum::tls_deserialize(&mut two_serialized).expect("Error deserializing.");
+
+    if let SimpleEnum::Two(_) = one {
+        panic!("Enum wrongly deserialized.")
+    };
+    if let SimpleEnum::One(_) = two {
+        panic!("Enum wrongly deserialized.")
+    };
 }
 
 #[test]

--- a/tls_codec_derive/tests/encode.rs
+++ b/tls_codec_derive/tests/encode.rs
@@ -62,6 +62,38 @@ fn lifetime_struct() {
     );
 }
 
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct CredentialType(u16);
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct SignatureScheme(u16);
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct BasicCredential {
+    identity: TlsVecU16<u8>,
+    signature_scheme: SignatureScheme,
+    signature_key: TlsVecU16<u8>,
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq, Debug)]
+#[repr(u8)]
+enum SimpleEnumType {
+    One = 1u8,
+    Two = 2u8,
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+enum SimpleEnum {
+    One(Credential),
+    Two(BasicCredential),
+}
+
+#[derive(TlsSerialize, TlsSize, Clone, PartialEq)]
+struct Credential {
+    credential_type: CredentialType,
+    credential: BasicCredential,
+}
+
 #[test]
 fn simple_enum() {
     let serialized = ExtensionType::KeyId.tls_serialize_detached().unwrap();
@@ -70,6 +102,21 @@ fn simple_enum() {
         .tls_serialize_detached()
         .unwrap();
     assert_eq!(vec![1, 244], serialized);
+
+    let basic_credential = BasicCredential {
+        identity: vec![].into(),
+        signature_scheme: SignatureScheme(0u16),
+        signature_key: vec![].into(),
+    };
+    let credential = Credential {
+        credential_type: CredentialType(0u16),
+        credential: basic_credential.clone(),
+    };
+    let one = SimpleEnum::One(credential);
+    let _one_serialized: Vec<u8> = one.tls_serialize_detached().unwrap();
+
+    let two = SimpleEnum::Two(basic_credential);
+    let _two_serialized: Vec<u8> = two.tls_serialize_detached().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #5 to a certain degree in that it is restricted to single-field tuple-structs with simple types.

Concretely, `parse_ast` now checks what kind of enum it is parsing and might error out if it isn't a repr enum or one as described above. I have also move the preparation of the `TokenStream2` vectors to where they are used to avoid bloating the `Enum` struct too much.